### PR TITLE
PHA Client Response and Server Processing

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -4523,6 +4523,8 @@ OPENSSL_EXPORT void SSL_set_post_handshake_auth(SSL *ssl, int val);
 // The |SSL_VERIFY_PEER| flag must be set; the |SSL_VERIFY_POST_HANDSHAKE|
 // flag is optional. These flags can be set via |SSL_CTX_set_verify| for
 // |SSL_CTX| or |SSL_set_verify| for |SSL|.
+// A custom verification callback function must be set via
+// |SSL_CTX_set_custom_verify| before the connection is established. 
 OPENSSL_EXPORT int SSL_verify_client_post_handshake(SSL *ssl);
 
 

--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -503,8 +503,6 @@ bool tls12_check_peer_sigalg(const SSL_HANDSHAKE *hs, uint8_t *out_alert,
 
 Array<uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs) {
   Span<const uint16_t> sigalgs = tls12_get_verify_sigalgs(hs);
-
-  // Create copy into array
   Array<uint16_t> copySigalgs;
   copySigalgs.CopyFrom(sigalgs);
   return copySigalgs;

--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -4149,6 +4149,7 @@ bool tls1_parse_peer_sigalgs(SSL_HANDSHAKE *hs, const CBS *in_sigalgs) {
 }
 
 bool tls13_parse_peer_sigalgs_pha(SSL *ssl, const CBS *in_sigalgs) {
+  assert(!ssl->server);
   return CBS_len(in_sigalgs) != 0 &&
          parse_u16_array(in_sigalgs, &ssl->s3->pha_config->verify_sigalgs);
 }
@@ -4167,6 +4168,7 @@ bool tls1_get_legacy_signature_algorithm(uint16_t *out, const EVP_PKEY *pkey) {
 }
 
 bool tls13_choose_signature_algorithm_pha(SSL *ssl, uint16_t *out) {
+  assert(!ssl->server);
   PHA_Config *config = ssl->s3->pha_config.get();
   CERT *cert = config->client_cert.get();
   Span<const uint16_t> peer_sigalgs = config->verify_sigalgs;

--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -4151,7 +4151,8 @@ bool tls1_parse_peer_sigalgs(SSL_HANDSHAKE *hs, const CBS *in_sigalgs) {
 }
 
 bool tls13_parse_peer_sigalgs_pha(SSL *ssl, const CBS *in_sigalgs) {
-  return false;
+  return CBS_len(in_sigalgs) != 0 &&
+         parse_u16_array(in_sigalgs, &ssl->s3->pha_config->verify_sigalgs);
 }
 
 bool tls1_get_legacy_signature_algorithm(uint16_t *out, const EVP_PKEY *pkey) {

--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -4152,6 +4152,10 @@ bool tls1_parse_peer_sigalgs(SSL_HANDSHAKE *hs, const CBS *in_sigalgs) {
          parse_u16_array(in_sigalgs, &hs->peer_sigalgs);
 }
 
+bool tls13_parse_peer_sigalgs_pha(SSL *ssl, const CBS *in_sigalgs) {
+  return false;
+}
+
 bool tls1_get_legacy_signature_algorithm(uint16_t *out, const EVP_PKEY *pkey) {
   switch (EVP_PKEY_id(pkey)) {
     case EVP_PKEY_RSA:

--- a/ssl/extensions.cc
+++ b/ssl/extensions.cc
@@ -501,15 +501,13 @@ bool tls12_check_peer_sigalg(const SSL_HANDSHAKE *hs, uint8_t *out_alert,
   return false;
 }
 
-Span<const uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs) {
+Array<uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs) {
   Span<const uint16_t> sigalgs = tls12_get_verify_sigalgs(hs);
-  // allocate space
-  uint16_t * copySigalgs = (uint16_t *) OPENSSL_malloc(sigalgs.size() * sizeof(uint16_t));
-  // copy over the data
-  OPENSSL_memcpy(copySigalgs, sigalgs.data(), sigalgs.size() * sizeof(uint16_t));
-  // create a span from the copied data
-  Span<const uint16_t> copySiglagsSpan(copySigalgs, sigalgs.size());
-  return copySiglagsSpan;
+
+  // Create copy into array
+  Array<uint16_t> copySigalgs;
+  copySigalgs.CopyFrom(sigalgs);
+  return copySigalgs;
 }
 
 bool tls13_add_verify_sigalgs_pha(SSL *ssl, CBB *out) {

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2207,7 +2207,7 @@ bool tls13_add_certificate_request(SSL *ssl);
 // tls13_process_certificate_request processes the CertificateRequest in |msg|
 // and returns true if processing is successful and response is sent, and false
 // otherwise
-bool tls13_process_certificate_request(SSL *ssl, const SSLMessage &msg);
+bool tls13_process_certificate_request_pha(SSL *ssl, const SSLMessage &msg);
 
 // tls13_post_handshake processes a post-handshake message. It returns true on
 // success and false on failure.
@@ -2419,6 +2419,11 @@ uint16_t ssl_get_grease_value(const SSL_HANDSHAKE *hs,
 // algorithms and saves them on |hs|. It returns true on success and false on
 // error.
 bool tls1_parse_peer_sigalgs(SSL_HANDSHAKE *hs, const CBS *sigalgs);
+
+// tls13_parse_peer_sigalgs_pha parses |sigalgs| as the list of peer signature
+// algorithms and saves them on |ssl|. This is specifically for the pha case
+// where we don't have the handshake object available.
+bool tls13_parse_peer_sigalgs_pha(SSL *ssl, const CBS *in_sigalgs);
 
 // tls1_get_legacy_signature_algorithm sets |*out| to the signature algorithm
 // that should be used with |pkey| in TLS 1.1 and earlier. It returns true on

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1347,6 +1347,10 @@ int ssl_write_buffer_flush(SSL *ssl);
 // configured.
 bool ssl_has_certificate(const SSL_HANDSHAKE *hs);
 
+// ssl_has_certificate_pha returns whether a certificate and private key are
+// configured for the pha case where the handshake object is not available.
+bool ssl_has_certificate_pha(const SSL *ssl);
+
 // ssl_parse_cert_chain parses a certificate list from |cbs| in the format used
 // by a TLS Certificate message. On success, it advances |cbs| and returns
 // true. Otherwise, it returns false and sets |*out_alert| to an alert to send
@@ -1422,6 +1426,12 @@ bool ssl_check_leaf_certificate(SSL_HANDSHAKE *hs, EVP_PKEY *pkey,
 // true on success and false on error.
 bool ssl_on_certificate_selected(SSL_HANDSHAKE *hs);
 
+
+// ssl_on_certificate_selected_pha is called once the certificate has been
+// selected. It finalizes the certificate and initializes
+// |ssl->s3->pha_config->client_pubkey|. It returns true on success and
+// false on error.
+bool ssl_on_certificate_selected_pha(SSL *ssl);
 
 // TLS 1.3 key derivation.
 

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2457,7 +2457,7 @@ bool tls12_check_peer_sigalg(const SSL_HANDSHAKE *hs, uint8_t *out_alert,
 // tls13_get_verify_sigalgs_pha calls |tls12_get_verify_sigalgs| for the given
 // handshake object. It takes the sigalgs returned, creates a deep copy, and
 // returns the copy. These are used for PHA .
-OPENSSL_EXPORT Span<const uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs);
+OPENSSL_EXPORT Array<uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs);
 
 // tls13_add_verify_sigalgs_pha adds the signature algorithms acceptable for the
 // peer signature to |out|. It returns true on success and false on error. This
@@ -2777,7 +2777,7 @@ enum ssl_ech_status_t {
 struct PHA_Config {
   static constexpr bool kAllowUniquePtr = true;
   // Holds negotiated sigalgs from the handshake for CertificateRequest message
-  Span<const uint16_t> verify_sigalgs;
+  Array<uint16_t> verify_sigalgs;
 
   // Holds CA's accepted by the server for CertificateRequest message
   const STACK_OF(CRYPTO_BUFFER) *names;

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2820,27 +2820,28 @@ enum ssl_ech_status_t {
 // at the end of the connection
 struct PHA_Config {
   static constexpr bool kAllowUniquePtr = true;
-  // Holds negotiated sigalgs from the handshake for CertificateRequest message
+  // verify_sigalgs holds negotiated sigalgs from the handshake for
+  // the CertificateRequest message
   Array<uint16_t> verify_sigalgs;
 
-  // Holds CA's accepted by the server for CertificateRequest message
+  // names holds CA's accepted by the server for CertificateRequest message
   const STACK_OF(CRYPTO_BUFFER) *names;
 
   // Holds original transcript hash for CertificateVerify from client response
-  uint8_t handshake_transcript_hash[EVP_MAX_MD_SIZE];
-  size_t handshake_transcript_hash_len;
+  // for PHA
   SSLTranscript transcript;
 
-  // Holds the client certificate
+  // client_cert is the configured client certificate
   UniquePtr<CERT> client_cert;
 
-  // client_pubkey is the public key the client is authenticating as.
+  // client_pubkey is the public key the client is authenticating as
   UniquePtr<EVP_PKEY> client_pubkey;
 
-  // Holds CertificateRequest context to be used by client when responding
+  // request_context is the context from CertificateRequest
+  // to be used by client when responding in Certificate message
   uint8_t request_context[16];
 
-  // Holds client handshake secret for Client Finished
+  // client_handshake_secret holds client handshake secret for Client Finished
   Span<uint8_t> client_handshake_secret;
 
   // scts_requested is true if the SCT extension is in the ClientHello.

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1395,7 +1395,7 @@ UniquePtr<STACK_OF(CRYPTO_BUFFER)> ssl_parse_client_CA_list(SSL *ssl,
 
 // ssl_get_client_CAs_pha creates a deep copy of the configured CA list and
 // returns a pointer to it. Otherwise, returns NULL.
-STACK_OF(CRYPTO_BUFFER) * ssl_get_client_CAs_pha(const SSL_HANDSHAKE *hs);
+OPENSSL_EXPORT STACK_OF(CRYPTO_BUFFER) * ssl_get_client_CAs_pha(const SSL_HANDSHAKE *hs);
 
 // ssl_add_client_CA_list_pha adds the configured CA list to |cbb| in the format
 // used by a TLS CertificateRequest message. It returns true on success and
@@ -2457,7 +2457,7 @@ bool tls12_check_peer_sigalg(const SSL_HANDSHAKE *hs, uint8_t *out_alert,
 // tls13_get_verify_sigalgs_pha calls |tls12_get_verify_sigalgs| for the given
 // handshake object. It takes the sigalgs returned, creates a deep copy, and
 // returns the copy. These are used for PHA .
-Span<const uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs);
+OPENSSL_EXPORT Span<const uint16_t> tls13_get_verify_sigalgs_pha(const SSL_HANDSHAKE *hs);
 
 // tls13_add_verify_sigalgs_pha adds the signature algorithms acceptable for the
 // peer signature to |out|. It returns true on success and false on error. This

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2780,6 +2780,18 @@ struct PHA_Config {
   // Holds original transcript hash for CertificateVerify from client response
   uint8_t handshake_transcript_hash[EVP_MAX_MD_SIZE];
   size_t handshake_transcript_hash_len;
+
+  // Holds the client certificate
+  UniquePtr<CERT> client_cert;
+
+  // client_pubkey is the public key the client is authenticating as.
+  UniquePtr<EVP_PKEY> client_pubkey;
+
+  // scts_requested is true if the SCT extension is in the ClientHello.
+  bool scts_requested : 1;
+
+  // ocsp_stapling_requested is true if a client requested OCSP stapling.
+  bool ocsp_stapling_requested : 1;
 };
 
 #define SSL3_SEND_ALERT_SIZE 2

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2780,6 +2780,7 @@ struct PHA_Config {
   // Holds original transcript hash for CertificateVerify from client response
   uint8_t handshake_transcript_hash[EVP_MAX_MD_SIZE];
   size_t handshake_transcript_hash_len;
+  SSLTranscript transcript;
 
   // Holds the client certificate
   UniquePtr<CERT> client_cert;

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2204,6 +2204,11 @@ bool tls13_add_key_update(SSL *ssl, int update_requested);
 // true on success and false on failure.
 bool tls13_add_certificate_request(SSL *ssl);
 
+// tls13_process_certificate_request processes the CertificateRequest in |msg|
+// and returns true if processing is successful and response is sent, and false
+// otherwise
+bool tls13_process_certificate_request(SSL *ssl, const SSLMessage &msg);
+
 // tls13_post_handshake processes a post-handshake message. It returns true on
 // success and false on failure.
 bool tls13_post_handshake(SSL *ssl, const SSLMessage &msg);

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -1426,12 +1426,12 @@ bool ssl_check_leaf_certificate(SSL_HANDSHAKE *hs, EVP_PKEY *pkey,
 // true on success and false on error.
 bool ssl_on_certificate_selected(SSL_HANDSHAKE *hs);
 
-
 // ssl_on_certificate_selected_pha is called once the certificate has been
 // selected. It finalizes the certificate and initializes
 // |ssl->s3->pha_config->client_pubkey|. It returns true on success and
 // false on error.
 bool ssl_on_certificate_selected_pha(SSL *ssl);
+
 
 // TLS 1.3 key derivation.
 
@@ -2235,6 +2235,12 @@ bool tls13_process_finished(SSL_HANDSHAKE *hs, const SSLMessage &msg,
 
 bool tls13_add_certificate(SSL_HANDSHAKE *hs);
 
+// tls13_add_certificate_pha constructs and adds a Certificate message to the
+// passed in |SSL| object. Only the timestamp and OCSP extensions are supported,
+// delegated credentials and certificate compression can be added
+// later if needed.
+bool tls13_add_certificate_pha(SSL *ssl);
+
 // tls13_add_certificate_verify adds a TLS 1.3 CertificateVerify message to the
 // handshake. If it returns |ssl_private_key_retry|, it should be called again
 // to retry when the signing operation is completed.
@@ -2802,6 +2808,9 @@ struct PHA_Config {
 
   // client_pubkey is the public key the client is authenticating as.
   UniquePtr<EVP_PKEY> client_pubkey;
+
+  // Holds CertificateRequest context to be used by client when responding
+  uint8_t request_context[16];
 
   // scts_requested is true if the SCT extension is in the ClientHello.
   bool scts_requested : 1;

--- a/ssl/ssl_cert.cc
+++ b/ssl/ssl_cert.cc
@@ -416,6 +416,7 @@ bool ssl_has_certificate(const SSL_HANDSHAKE *hs) {
 }
 
 bool ssl_has_certificate_pha(const SSL *ssl) {
+  assert(!ssl->server);
   if (!ssl_cert_check_cert_private_keys_usage(ssl->s3->pha_config->client_cert.get())) {
     return false;
   }
@@ -875,6 +876,7 @@ bool ssl_on_certificate_selected(SSL_HANDSHAKE *hs) {
 }
 
 bool ssl_on_certificate_selected_pha(SSL *ssl) {
+  assert(!ssl->server);
   if (!ssl_has_certificate_pha(ssl)) {
     // Nothing to do.
     return true;

--- a/ssl/ssl_lib.cc
+++ b/ssl/ssl_lib.cc
@@ -940,12 +940,6 @@ void SSL_set_post_handshake_auth(SSL *ssl, int val) {
   ssl->s3->pha_enabled = val;
 }
 
-// SSL_verify_client_post_handshake puts a CertificateRequest on the wire
-// to authenticate the client post handshake. The request is not flushed until
-// the next server write. Returns 1 on success and 0 otherwise.
-
-// TO-DO: SHOULD WE BE FLUSHING IN THIS CASE? SINCE THIS IS AFTER THE HANDSHAKE
-// TO-DO: Verify what error messages should be returned
 int SSL_verify_client_post_handshake(SSL *ssl) {
   ssl_reset_error_state(ssl);
 

--- a/ssl/ssl_privkey.cc
+++ b/ssl/ssl_privkey.cc
@@ -234,7 +234,7 @@ enum ssl_private_key_result_t ssl_private_key_sign_pha(
 
   PHA_Config *config = ssl->s3->pha_config.get();
   const SSL_PRIVATE_KEY_METHOD *key_method = config->client_cert->key_method;
-  if (!ssl_cert_check_cert_private_keys_usage(config->client_cert.get())) {
+  if (!ssl_cert_check_cert_private_keys_usage(  config->client_cert.get())) {
     return ssl_private_key_failure;
   }
   EVP_PKEY *privatekey =

--- a/ssl/ssl_privkey.cc
+++ b/ssl/ssl_privkey.cc
@@ -232,6 +232,7 @@ enum ssl_private_key_result_t ssl_private_key_sign_pha(
     SSL *ssl, uint8_t *out, size_t *out_len, size_t max_out,
    uint16_t sigalg, Span<const uint8_t> in) {
 
+  assert(!ssl->server);
   PHA_Config *config = ssl->s3->pha_config.get();
   const SSL_PRIVATE_KEY_METHOD *key_method = config->client_cert->key_method;
   if (!ssl_cert_check_cert_private_keys_usage(  config->client_cert.get())) {
@@ -429,6 +430,7 @@ static bool ssl_private_key_supports_signature_algorithm_helper(SSL *ssl, EVP_PK
 }
 
 bool ssl_private_key_supports_signature_algorithm_pha(SSL *ssl, uint16_t sigalg) {
+  assert(!ssl->server);
   return ssl_private_key_supports_signature_algorithm_helper(ssl, ssl->s3->pha_config->client_pubkey.get(), sigalg);
 }
 

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -8959,7 +8959,7 @@ TEST(SSLTest, ImmediatePHA) {
   EXPECT_TRUE(client.get()->s3->pha_ext == SSL_PHA_EXT_SENT);
 
   // Storing sigalgs since handshake object is destroyed in next server processing
-  Span<const uint16_t> verify_sigalgs = tls13_get_verify_sigalgs_pha(server.get()->s3->hs.get());
+  Array<uint16_t> verify_sigalgs = tls13_get_verify_sigalgs_pha(server.get()->s3->hs.get());
   // Storing clientCA list before copy
   const STACK_OF(CRYPTO_BUFFER) *names = ssl_get_client_CAs_pha(server.get()->s3->hs.get());
 
@@ -8971,7 +8971,7 @@ TEST(SSLTest, ImmediatePHA) {
   // Check initialization of PHA_config struct
   EXPECT_TRUE(server.get()->s3->pha_config != nullptr);
   // Get deep copy of verify_sigalgs made for PHA
-  Span<const uint16_t> copy_sigalgs = server.get()->s3->pha_config->verify_sigalgs;
+  Array<uint16_t>& copy_sigalgs = server.get()->s3->pha_config->verify_sigalgs;
   const STACK_OF(CRYPTO_BUFFER) *names_copy = server.get()->s3->pha_config->names;
 
   // Verify copying of sigalgs

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -8928,6 +8928,11 @@ TEST(SSLTest, ImmediatePHA) {
   // handshake
   SSL_CTX_set_verify(server_ctx.get(), SSL_VERIFY_PEER | SSL_VERIFY_POST_HANDSHAKE, nullptr);
 
+  // Custom verification functions that return ok
+  SSL_CTX_set_custom_verify(
+      server_ctx.get(), SSL_VERIFY_PEER | SSL_VERIFY_POST_HANDSHAKE,
+      [](SSL *ssl, uint8_t *out_alert) { return ssl_verify_ok; });
+
   // Configure trust store for server.
   SSL_CTX_set_client_CA_list(server_ctx.get(), get_test_cert_store());
 
@@ -9049,6 +9054,12 @@ TEST(SSLTest, ImmediatePHA) {
   }
   // Check if the underlying data is different (deep copy check)
   EXPECT_TRUE(verify_sigalgs.data() != sigalgs_client_copy.data());
+
+  // Arbitrary read length, we still process full flight of pending messages
+  // SSL_read(server.get(), nullptr, 2);
+
+  // Ensure verification result is successful
+  // EXPECT_EQ(SSL_get_verify_result_pha(server.get()), X509_V_OK);
 }
 
 // Testing: when PHA extension is sent by the client and the server does not a

--- a/ssl/ssl_test.cc
+++ b/ssl/ssl_test.cc
@@ -8959,7 +8959,7 @@ TEST(SSLTest, ImmediatePHA) {
   bool scts_before = client.get()->s3->hs->scts_requested;
   bool ocsp_before = client.get()->s3->hs->ocsp_stapling_requested;
 
-  EXPECT_EQ(client.get()->s3->pha_config, nullptr);
+  EXPECT_FALSE(client.get()->s3->pha_config);
 
   // Second client flight, process server messages and send client Finished
   SSL_do_handshake(client.get());
@@ -8970,7 +8970,7 @@ TEST(SSLTest, ImmediatePHA) {
 
   // Should have initialized PHA_Config on client side since pha is enabled
   // and should have copied appropriate data
-  EXPECT_NE(client.get()->s3->pha_config, nullptr);
+  EXPECT_TRUE(client.get()->s3->pha_config);
   EXPECT_EQ(client_cert_before->cert_private_key_idx, client_cert_after->cert_private_key_idx);
   EXPECT_EQ(client_cert_before->cert_private_keys.size(), client_cert_after->cert_private_keys.size());
   EXPECT_EQ(scts_before, client.get()->s3->pha_config->scts_requested);
@@ -9045,7 +9045,7 @@ TEST(SSLTest, ImmediatePHA) {
   EXPECT_TRUE(verify_sigalgs.size() == sigalgs_client_copy.size());
   // Check if the contents are the same in the same order
   for (size_t i = 0; i < verify_sigalgs.size(); ++i) {
-    EXPECT_TRUE(verify_sigalgs[i] == sigalgs_client_copy[i]);
+    EXPECT_EQ(verify_sigalgs[i], sigalgs_client_copy[i]);
   }
   // Check if the underlying data is different (deep copy check)
   EXPECT_TRUE(verify_sigalgs.data() != sigalgs_client_copy.data());

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -618,8 +618,11 @@ bool tls13_add_finished(SSL_HANDSHAKE *hs) {
     return false;
   }
 
-  // TO-DO: If PHA enabled, create copy of message and hash into transcript. Then also need to add CertificateRequest to the hash
+  // TO-DO: If PHA enabled, create copy of message and hash into transcript.
+  // Then also need to add CertificateRequest to the hash
+  if (ssl->s3->pha_config != nullptr) {
 
+  }
 
   return true;
 }

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -622,6 +622,7 @@ bool tls13_add_finished(SSL_HANDSHAKE *hs) {
   // Then also need to add CertificateRequest to the hash
   if (ssl->s3->pha_config != nullptr) {
 
+
   }
 
   return true;

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -108,6 +108,7 @@ bool tls13_get_cert_verify_signature_input(
 // TLS 1.3's CertificateVerify message. It sets |*out| to a newly allocated
 // buffer containing the result.
 static bool tls13_get_cert_verify_signature_input_pha(SSL *ssl, Array<uint8_t> *out) {
+  assert(!ssl->server);
   return tls13_get_cert_verify_signature_input_helper(ssl->s3->pha_config->transcript, out, ssl_cert_verify_client);
 }
 
@@ -402,6 +403,7 @@ bool tls13_process_finished(SSL_HANDSHAKE *hs, const SSLMessage &msg,
 }
 
 bool tls13_add_certificate_pha(SSL *ssl) {
+  assert(!ssl->server);
   CERT *const cert = ssl->s3->pha_config->client_cert.get();
 
   ScopedCBB cbb;
@@ -644,6 +646,7 @@ bool tls13_add_certificate(SSL_HANDSHAKE *hs) {
 }
 
 enum ssl_private_key_result_t tls13_add_certificate_verify_pha(SSL *ssl) {
+  assert(!ssl->server);
   uint16_t signature_algorithm;
   if (!tls13_choose_signature_algorithm_pha(ssl, &signature_algorithm)) {
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_HANDSHAKE_FAILURE);
@@ -764,6 +767,7 @@ bool tls13_add_finished_pha(SSL *ssl) {
   size_t verify_data_len;
   uint8_t verify_data[EVP_MAX_MD_SIZE];
 
+  assert(!ssl->server);
   if (!tls13_finished_mac_pha(ssl, verify_data, &verify_data_len)) {
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
     OPENSSL_PUT_ERROR(SSL, SSL_R_DIGEST_CHECK_FAILED);

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -439,11 +439,6 @@ bool tls13_add_certificate_pha(SSL *ssl) {
     return false;
   }
 
-  if (!ssl_has_certificate_pha(ssl)) {
-    return ssl_add_message_cbb(ssl, cbb.get());
-  }
-
-  // |cert_private_keys| already checked above in |ssl_has_certificate|.
   UniquePtr<STACK_OF(CRYPTO_BUFFER)> &chain =
       cert->cert_private_keys[cert->cert_private_key_idx].chain;
   CRYPTO_BUFFER *leaf_buf = sk_CRYPTO_BUFFER_value(chain.get(), 0);

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -618,13 +618,6 @@ bool tls13_add_finished(SSL_HANDSHAKE *hs) {
     return false;
   }
 
-  // TO-DO: If PHA enabled, create copy of message and hash into transcript.
-  // Then also need to add CertificateRequest to the hash
-  if (ssl->s3->pha_config != nullptr) {
-
-
-  }
-
   return true;
 }
 

--- a/ssl/tls13_both.cc
+++ b/ssl/tls13_both.cc
@@ -668,16 +668,6 @@ static bool tls13_receive_key_update(SSL *ssl, const SSLMessage &msg) {
   return true;
 }
 
-bool tls13_process_certificate_request(SSL *ssl, const SSLMessage &msg) {
-  // Did not enable and send pha_ext, should not have received this message
-  if(ssl->s3->pha_enabled != 1 || ssl->s3->pha_ext != SSL_PHA_EXT_SENT) {
-    OPENSSL_PUT_ERROR(SSL, SSL3_AD_UNEXPECTED_MESSAGE);
-    return false;
-  }
-
-  return true;
-}
-
 bool tls13_post_handshake(SSL *ssl, const SSLMessage &msg) {
   if (msg.type == SSL3_MT_KEY_UPDATE) {
     if (ssl->quic_method != nullptr) {
@@ -694,7 +684,7 @@ bool tls13_post_handshake(SSL *ssl, const SSLMessage &msg) {
   }
 
   if (msg.type == SSL3_MT_CERTIFICATE_REQUEST && !ssl->server) {
-    return tls13_process_certificate_request(ssl, msg);
+    return tls13_process_certificate_request_pha(ssl, msg);
   }
 
   ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_UNEXPECTED_MESSAGE);

--- a/ssl/tls13_client.cc
+++ b/ssl/tls13_client.cc
@@ -893,7 +893,7 @@ static enum ssl_hs_wait_t do_send_client_certificate_verify(SSL_HANDSHAKE *hs) {
 static enum ssl_hs_wait_t do_process_pha(SSL_HANDSHAKE *hs) {
   SSL *const ssl = hs->ssl;
 
-  if(ssl->s3->pha_ext == SSL_PHA_EXT_SENT && ssl->s3->pha_enabled == 1) {
+  if(ssl->s3->pha_ext == SSL_PHA_EXT_SENT && ssl->s3->pha_enabled) {
 
     ssl->s3->pha_config = MakeUnique<PHA_Config>();
     if (ssl->s3->pha_config == nullptr) {
@@ -1151,7 +1151,7 @@ static bool tls13_add_empty_certificate(SSL *ssl) {
 }
 
 bool tls13_process_certificate_request_pha(SSL *ssl, const SSLMessage &msg) {
-  if(ssl->s3->pha_enabled != 1 || ssl->s3->pha_ext != SSL_PHA_EXT_SENT) {
+  if(!ssl->s3->pha_enabled || ssl->s3->pha_ext != SSL_PHA_EXT_SENT) {
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_UNEXPECTED_MESSAGE);
     OPENSSL_PUT_ERROR(SSL, SSL3_AD_UNEXPECTED_MESSAGE);
     return false;

--- a/ssl/tls13_client.cc
+++ b/ssl/tls13_client.cc
@@ -1110,7 +1110,9 @@ static bool tls13_parse_certificate_request_pha(SSL *ssl, const SSLMessage &msg)
     OPENSSL_PUT_ERROR(SSL, SSL_R_DECODE_ERROR);
     return false;
   }
-
+  uint8_t req_context[16];
+  CBS_copy_bytes(&context, req_context, CBS_len(&context));
+  OPENSSL_memcpy(ssl->s3->pha_config->request_context, req_context, sizeof(req_context));
   if (ca.present) {
     ssl->s3->pha_config->names =
         ssl_parse_client_CA_list(ssl, &alert, &ca.data).get();
@@ -1155,6 +1157,11 @@ bool tls13_process_certificate_request_pha(SSL *ssl, const SSLMessage &msg) {
     }
 
     if(!ssl_on_certificate_selected_pha(ssl)) {
+      return false;
+    }
+
+
+    if(!tls13_add_certificate_pha(ssl)) {
       return false;
     }
 

--- a/ssl/tls13_client.cc
+++ b/ssl/tls13_client.cc
@@ -1091,6 +1091,7 @@ bool tls13_process_new_session_ticket(SSL *ssl, const SSLMessage &msg) {
   return true;
 }
 static bool tls13_parse_certificate_request_pha(SSL *ssl, const SSLMessage &msg) {
+  assert(!ssl->server);
   SSLExtension sigalgs(TLSEXT_TYPE_signature_algorithms),
       ca(TLSEXT_TYPE_certificate_authorities);
   CBS body = msg.body, context, extensions, supported_signature_algorithms;
@@ -1129,6 +1130,7 @@ static bool tls13_parse_certificate_request_pha(SSL *ssl, const SSLMessage &msg)
 // authentication and the request context is not empty as is the case in a
 // normal handshake
 static bool tls13_add_empty_certificate(SSL *ssl) {
+  assert(!ssl->server);
   ScopedCBB cbb;
   CBB *body, body_storage, context;
 
@@ -1151,6 +1153,7 @@ static bool tls13_add_empty_certificate(SSL *ssl) {
 }
 
 bool tls13_process_certificate_request_pha(SSL *ssl, const SSLMessage &msg) {
+  assert(!ssl->server);
   if(!ssl->s3->pha_enabled || ssl->s3->pha_ext != SSL_PHA_EXT_SENT) {
     ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_UNEXPECTED_MESSAGE);
     OPENSSL_PUT_ERROR(SSL, SSL3_AD_UNEXPECTED_MESSAGE);

--- a/ssl/tls13_client.cc
+++ b/ssl/tls13_client.cc
@@ -1108,25 +1108,17 @@ static bool tls13_parse_certificate_request_pha(SSL *ssl, const SSLMessage &msg)
       !tls13_parse_peer_sigalgs_pha(ssl, &supported_signature_algorithms)) {
     ssl_send_alert(ssl, SSL3_AL_FATAL, alert);
     OPENSSL_PUT_ERROR(SSL, SSL_R_DECODE_ERROR);
-    return ssl_hs_error;
+    return false;
   }
 
   if (ca.present) {
-    ssl->s3->pha_config->names = ssl_parse_client_CA_list(ssl, &alert, &ca.data).get();
+    ssl->s3->pha_config->names =
+        ssl_parse_client_CA_list(ssl, &alert, &ca.data).get();
     if (!ssl->s3->pha_config->names) {
       ssl_send_alert(ssl, SSL3_AL_FATAL, alert);
-      return ssl_hs_error;
+      return false;
     }
   }
-  // MAY NOT NEED THIS PART OF CODE, IS IT NECESSARY TO RESET THE VALUE OF NAMES
-  else {
-    ssl->s3->pha_config->names = sk_CRYPTO_BUFFER_new_null();
-    if (!ssl->s3->pha_config->names) {
-      ssl_send_alert(ssl, SSL3_AL_FATAL, SSL_AD_INTERNAL_ERROR);
-      return ssl_hs_error;
-    }
-  }
-
   return true;
 }
 

--- a/ssl/tls13_client.cc
+++ b/ssl/tls13_client.cc
@@ -911,7 +911,7 @@ static enum ssl_hs_wait_t do_process_pha(SSL_HANDSHAKE *hs) {
 
     Span<uint8_t> original = hs->client_handshake_secret();
     uint8_t copiedData[sizeof(original)];
-    std::memcpy(copiedData, original.data(), original.size());
+    OPENSSL_memcpy(copiedData, original.data(), original.size());
     Span<uint8_t> copiedSpan(copiedData, sizeof(copiedData));
     ssl->s3->pha_config->client_handshake_secret = copiedSpan;
   }

--- a/ssl/tls13_enc.cc
+++ b/ssl/tls13_enc.cc
@@ -379,6 +379,7 @@ bool tls13_finished_mac(SSL_HANDSHAKE *hs, uint8_t *out, size_t *out_len,
 }
 
 bool tls13_finished_mac_pha(SSL *ssl, uint8_t *out, size_t *out_len) {
+  assert(!ssl->server);
   PHA_Config *config = ssl->s3->pha_config.get();
   Span<const uint8_t> traffic_secret = config->client_handshake_secret;
 

--- a/ssl/tls13_enc.cc
+++ b/ssl/tls13_enc.cc
@@ -379,7 +379,6 @@ bool tls13_finished_mac(SSL_HANDSHAKE *hs, uint8_t *out, size_t *out_len,
 }
 
 bool tls13_finished_mac_pha(SSL *ssl, uint8_t *out, size_t *out_len) {
-  assert(!ssl->server);
   PHA_Config *config = ssl->s3->pha_config.get();
   Span<const uint8_t> traffic_secret = config->client_handshake_secret;
 

--- a/ssl/tls13_enc.cc
+++ b/ssl/tls13_enc.cc
@@ -353,35 +353,36 @@ static bool tls13_verify_data(uint8_t *out, size_t *out_len,
   return true;
 }
 
-bool tls13_finished_mac(SSL_HANDSHAKE *hs, uint8_t *out, size_t *out_len,
-                        bool is_server) {
-  Span<const uint8_t> traffic_secret =
-      is_server ? hs->server_handshake_secret() : hs->client_handshake_secret();
-
+// tls13_finished_mac_helper abstracts functionality from
+// |tls13_finished_mac| to account for the PHA case where |transcript| is not
+// located in the same place and |hs_secret| may be different
+static bool tls13_finished_mac_helper(SSL *ssl, SSLTranscript &transcript,
+                                      uint8_t *out, size_t *out_len,
+                                      Span<const uint8_t> &hs_secret) {
   uint8_t context_hash[EVP_MAX_MD_SIZE];
   size_t context_hash_len;
-  if (!hs->transcript.GetHash(context_hash, &context_hash_len) ||
-      !tls13_verify_data(out, out_len, hs->transcript.Digest(),
-                         hs->ssl->version, traffic_secret,
+  if (!transcript.GetHash(context_hash, &context_hash_len) ||
+      !tls13_verify_data(out, out_len, transcript.Digest(),
+                         ssl->version, hs_secret,
                          MakeConstSpan(context_hash, context_hash_len))) {
     return false;
   }
   return true;
 }
 
+bool tls13_finished_mac(SSL_HANDSHAKE *hs, uint8_t *out, size_t *out_len,
+                        bool is_server) {
+  Span<const uint8_t> traffic_secret =
+      is_server ? hs->server_handshake_secret() : hs->client_handshake_secret();
+
+  return tls13_finished_mac_helper(hs->ssl, hs->transcript, out, out_len, traffic_secret);
+}
+
 bool tls13_finished_mac_pha(SSL *ssl, uint8_t *out, size_t *out_len) {
   PHA_Config *config = ssl->s3->pha_config.get();
   Span<const uint8_t> traffic_secret = config->client_handshake_secret;
 
-  uint8_t context_hash[EVP_MAX_MD_SIZE];
-  size_t context_hash_len;
-  if (!config->transcript.GetHash(context_hash, &context_hash_len) ||
-      !tls13_verify_data(out, out_len, config->transcript.Digest(),
-                         ssl->version, traffic_secret,
-                         MakeConstSpan(context_hash, context_hash_len))) {
-    return false;
-  }
-  return true;
+  return tls13_finished_mac_helper(ssl, config->transcript, out, out_len, traffic_secret);
 }
 
 static const char kTLS13LabelResumptionPSK[] = "resumption";

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -1279,8 +1279,6 @@ static enum ssl_hs_wait_t do_certificate_request_pha(SSL_HANDSHAKE *hs) {
       // Note, this value may be NULL
       ssl->s3->pha_config->names = ssl_get_client_CAs_pha(hs);
     }
-
-    // TO-DO: Store the handshake transcript
   }
 
   // Cert request wasn't sent in initial handshake but client auth is requested,


### PR DESCRIPTION
### Description of changes:
- Added states in TLS 1.3 client state machine to process PHA during handshake and copy relevant data
- Processing Certificate Request from Server
   - Defined `tls13_process_certificate_request_pha`
      - Defined `tls13_parse_certificate_request_pha`
         - Defined `tls13_parse_peer_sigalgs_pha`

- Sending Certificate
   - Defined `ssl_on_certificate_selected_pha`
      - Defined `ssl_has_certificate_pha`   
   - Defined `tls13_add_certificate_pha`
   - Defined `tls13_add_empty_certificate`

- Sending CertificateVerify
   - Defined `tls13_add_certificate_verify_pha`
      - Defined `tls13_choose_signature_algorithm_pha`
         - Defined `ssl_private_key_supports_signature_algorithm_pha` (and `ssl_private_key_supports_signature_algorithm_pha_helper`)
      - Defined `tls13_get_cert_verify_signature_input_pha` (and  `tls13_get_cert_verify_signature_input_pha_helper`)
      - Defined `ssl_private_key_sign_pha` 

- Sending Finished
   - Defined `tls13_add_finished_pha`
      - Defined `tls13_finished_mac_pha` (and `tls13_finished_mac_pha_helper`)

- State being copied to PHA_Config
   ```
   - SSLTranscript transcript
   - UniquePtr<CERT> client_cert
   - UniquePtr<EVP_PKEY> client_pubkey
   - uint8_t request_context[16]
   - Span<uint8_t> client_handshake_secret
   - bool scts_requested
   - bool ocsp_stapling_requested 
   ```

- Processing Client Response: 
   - tls13_process_client_response_pha
      - tls13_get_cert_verify_signature_input_pha
      - tls13_process_certificate_pha
      - tls13_check_peer_sigalg_pha
      - tls13_process_certificate_verify_pha
      - tls13_process_finished_pha
      - tls13_finished_mac_pha
    - SSL_get_verify_result_pha

State being saved to PHA_Config: 
- Client Certificate
- Client Public Key
- Verification Result 

### Testing:
- Testing copying of information during state machine
- Testing parsing of information from CertificateRequest and copying into PHA_Config
- Ensuring client sends a valid response

### Callouts: 
- Verifying the signature for the CertificateVerify message is failing currently. Not sure exactly what the bug is, needs further investigation. The test "ImmediatePHA" has commented code at the bottom to trigger the bug. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
